### PR TITLE
minimal and ubuntu 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,51 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
-RUN apt-get update && apt-get install -y \
-    libtiff-dev libgeotiff-dev libgdal-dev \
-    libboost-system-dev libboost-thread-dev libboost-filesystem-dev libboost-program-options-dev libboost-regex-dev libboost-iostreams-dev \
-    git cmake build-essential wget software-properties-common
+ENV DEBIAN_FRONTEND=noninteractive
 
-WORKDIR /opt
-
-RUN git clone https://github.com/LAStools/LAStools
-
-WORKDIR /opt/LAStools
-
-RUN git checkout master && \
-    make all
-
-ENV PATH /opt/LAStools/bin/:$PATH
+RUN apt-get -qq -y update \
+    && apt-get install -qq -y \
+    libtiff5 \
+    libgeotiff5 \
+    libgdal26 \
+    libboost-system1.71.0 \
+    libboost-thread1.71.0 \
+    libboost-filesystem1.71.0 \
+    libboost-program-options1.71.0 \
+    libboost-regex1.71.0 \
+    libboost-iostreams1.71.0 \
+    libtiff-dev \
+    libgeotiff-dev \
+    libgdal-dev \
+    libboost-system-dev \
+    libboost-thread-dev \
+    libboost-filesystem-dev \
+    libboost-program-options-dev \
+    libboost-regex-dev \
+    libboost-iostreams-dev \
+    git \
+    cmake \
+    g++ \
+    && mkdir /src \
+    && cd /src \
+    && git clone https://github.com/LAStools/LAStools \
+    && cd LAStools \
+    && make all \
+    && cd bin \
+    && install lasinfo laszip lasprecision las2txt txt2las las2las lasdiff lasmerge /usr/local/bin \
+    && cd / \
+    && rm -fr /src \
+    && apt-get remove -qq -y \
+    libtiff-dev \
+    libgeotiff-dev \
+    libgdal-dev \
+    libboost-system-dev \
+    libboost-thread-dev \
+    libboost-filesystem-dev \
+    libboost-program-options-dev \
+    libboost-regex-dev \
+    libboost-iostreams-dev \
+    git \
+    cmake \
+    g++ \
+    && apt-get autoremove -qq -y \
+    && rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # docker-lastools
 Docker for LAStools  
-Based on Ubuntu 18.04 bionic  
+Based on Ubuntu 20.04 focal
 
 This container has the open source versions listed on https://github.com/LAStools/LAStools  
 


### PR DESCRIPTION
- pass the tzdata question in `apt-get install`
- minimal docker image size
- use ubuntu 20.04